### PR TITLE
speedup boot, without wait 30 seconds

### DIFF
--- a/scripts/local
+++ b/scripts/local
@@ -13,6 +13,8 @@ pre_mountroot()
 	fi
 
 	while [ -z "${FSTYPE}" ]; do
+		break
+	
 		FSTYPE=$(wait-for-root "${ROOT}" ${ROOTDELAY:-30})
 
 		# Load ubi with the correct MTD partition and return since


### PR DESCRIPTION
UBI may be disabled, but we do not use it.
